### PR TITLE
feat(content): add learning platforms to certifications section

### DIFF
--- a/src/components/Certifications.tsx
+++ b/src/components/Certifications.tsx
@@ -5,7 +5,7 @@ import {
   CertificationItem,
 } from "@/data/certificationsData";
 import { FaCertificate, FaExternalLinkAlt, FaUniversity } from "react-icons/fa";
-import { FiClock } from "react-icons/fi";
+import { FiClock, FiActivity } from "react-icons/fi";
 import Section from "./Section";
 import Panel from "./Panel";
 
@@ -24,7 +24,11 @@ const Certifications = () => {
               className="flex flex-col h-full group w-full">
               <div className="flex-grow mb-4">
                 <div className="flex items-start mb-3">
-                  <FaCertificate className="w-5 h-5 md:w-6 md:h-6 mr-3 mt-1 text-info-accent flex-shrink-0 group-hover:text-accent transition-colors" />
+                  {cert.isInProgress ? (
+                    <FiActivity className="w-5 h-5 md:w-6 md:h-6 mr-3 mt-1 text-info-accent flex-shrink-0 group-hover:text-accent transition-colors" />
+                  ) : (
+                    <FaCertificate className="w-5 h-5 md:w-6 md:h-6 mr-3 mt-1 text-info-accent flex-shrink-0 group-hover:text-accent transition-colors" />
+                  )}
                   <p className="text-base md:text-lg font-semibold text-accent group-hover:text-accent-hover transition-colors leading-tight">
                     {cert.name}
                   </p>
@@ -45,15 +49,27 @@ const Certifications = () => {
                 )}
               </div>
               <div className="mt-auto pt-4 border-t border-neutral-700/30">
-                <a
-                  href={cert.credentialUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={`Verify ${cert.name} certificate`}
-                  className="inline-flex items-center justify-center w-full text-sm text-info-accent hover:text-accent font-medium transition-colors duration-300 bg-primary-bg/70 hover:bg-primary-bg px-4 py-2.5 rounded-md border border-info-accent/50 hover:border-accent interactive-glow">
-                  <FaExternalLinkAlt className="mr-2 h-3.5 w-3.5" />
-                  Verify Certificate
-                </a>
+                {cert.isInProgress ? (
+                  <a
+                    href={cert.credentialUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`View progress for ${cert.name}`}
+                    className="inline-flex items-center justify-center w-full text-sm text-info-accent hover:text-accent font-medium transition-colors duration-300 bg-primary-bg/70 hover:bg-primary-bg px-4 py-2.5 rounded-md border border-info-accent/50 hover:border-accent interactive-glow">
+                    <FiActivity className="mr-2 h-3.5 w-3.5" />
+                    View Progress
+                  </a>
+                ) : (
+                  <a
+                    href={cert.credentialUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Verify ${cert.name} certificate`}
+                    className="inline-flex items-center justify-center w-full text-sm text-info-accent hover:text-accent font-medium transition-colors duration-300 bg-primary-bg/70 hover:bg-primary-bg px-4 py-2.5 rounded-md border border-info-accent/50 hover:border-accent interactive-glow">
+                    <FaExternalLinkAlt className="mr-2 h-3.5 w-3.5" />
+                    Verify Certificate
+                  </a>
+                )}
               </div>
             </Panel>
           ))}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -4,7 +4,6 @@
 import React from "react";
 import Section from "./Section";
 import Panel from "./Panel";
-import { FiExternalLink } from "react-icons/fi";
 import { clsx } from "clsx";
 
 interface SkillItem {
@@ -18,6 +17,7 @@ interface SkillCategory {
   skills: SkillItem[];
 }
 
+// UPDATED: LeetCode item removed from the list.
 const SKILL_CATEGORIES: SkillCategory[] = [
   {
     id: "languages",
@@ -126,12 +126,6 @@ const SKILL_CATEGORIES: SkillCategory[] = [
     id: "problem-solving",
     title: "Problem Solving & DSA",
     skills: [
-      // UPDATED "LeetCode" text and description
-      {
-        name: "LeetCode (In Progress)",
-        description:
-          "Actively solving challenges to sharpen data structure and algorithm skills.",
-      },
       {
         name: "Data Structures",
         description:
@@ -244,20 +238,10 @@ const Skills: React.FC = () => {
       <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 items-start">
         {SKILL_CATEGORIES.map((category) => (
           <Panel as="li" key={category.id} className="h-full" variant="simple">
-            {category.id === "problem-solving" ? (
-              <a
-                href="https://leetcode.com/u/joaoptgrilo/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block font-fira_code text-xl md:text-2xl text-info-accent mb-4 font-semibold group hover:text-accent transition-colors duration-300">
-                {category.title}
-                <FiExternalLink className="inline-block w-4 h-4 ml-2 mb-1 opacity-70 group-hover:opacity-100 transition-opacity" />
-              </a>
-            ) : (
-              <p className="font-fira_code text-xl md:text-2xl text-info-accent mb-4 font-semibold">
-                {category.title}
-              </p>
-            )}
+            {/* UPDATED: Removed conditional link logic. All titles are now plain text. */}
+            <p className="font-fira_code text-xl md:text-2xl text-info-accent mb-4 font-semibold">
+              {category.title}
+            </p>
             <div className="flex flex-wrap gap-2">
               {category.skills.map((skill) => (
                 <span

--- a/src/data/certificationsData.tsx
+++ b/src/data/certificationsData.tsx
@@ -1,6 +1,6 @@
 // src/data/certificationsData.tsx
 import React from "react";
-import Highlight from "@/components/Highlight"; // Assuming Highlight component path
+import Highlight from "@/components/Highlight";
 
 export interface CertificationItem {
   id: string;
@@ -9,8 +9,8 @@ export interface CertificationItem {
   issueDate?: string;
   credentialUrl: string;
   icon?: React.ElementType;
-  description?: React.ReactNode; // UPDATED to React.ReactNode
-  isInProgress?: boolean; // For styling "In Progress" items if needed
+  description?: React.ReactNode;
+  isInProgress?: boolean;
 }
 
 export const certificationsData: CertificationItem[] = [
@@ -20,7 +20,6 @@ export const certificationsData: CertificationItem[] = [
     issuer: "freeCodeCamp",
     credentialUrl:
       "https://www.freecodecamp.org/certification/JoaoGrilo/responsive-web-design",
-    // UPDATED with Highlights
     description: (
       <>
         Covers <Highlight>HTML</Highlight>, <Highlight>CSS</Highlight>, Visual
@@ -36,7 +35,6 @@ export const certificationsData: CertificationItem[] = [
     issuer: "freeCodeCamp",
     credentialUrl:
       "https://www.freecodecamp.org/certification/JoaoGrilo/javascript-algorithms-and-data-structures-v8",
-    // UPDATED with Highlights
     description: (
       <>
         Focuses on JavaScript fundamentals, <Highlight>ES6</Highlight>, Regular
@@ -52,7 +50,6 @@ export const certificationsData: CertificationItem[] = [
     issuer: "freeCodeCamp",
     credentialUrl:
       "https://www.freecodecamp.org/certification/JoaoGrilo/front-end-development-libraries",
-    // UPDATED with Highlights
     description: (
       <>
         Teaches modern frontend libraries including{" "}
@@ -67,7 +64,6 @@ export const certificationsData: CertificationItem[] = [
     issuer: "freeCodeCamp",
     credentialUrl:
       "https://www.freecodecamp.org/certification/JoaoGrilo/data-visualization",
-    // UPDATED with Highlights
     description: (
       <>
         Focuses on <Highlight>D3.js</Highlight> fundamentals, creating bar
@@ -76,13 +72,49 @@ export const certificationsData: CertificationItem[] = [
       </>
     ),
   },
-  // Example for an "In Progress" item (we can style it differently later):
-  // {
-  //   id: 'aws-cloud-quest',
-  //   name: 'AWS Cloud Quest: Cloud Practitioner',
-  //   issuer: 'Amazon Web Services',
-  //   credentialUrl: '#',
-  //   description: <>Hands-on learning for <Highlight>AWS Cloud fundamentals</Highlight> and core services.</>,
-  //   isInProgress: true,
-  // },
+  // START: NEW/UPDATED "CONTINUED LEARNING" ITEMS
+  {
+    id: "leetcode-problem-solving",
+    name: "LeetCode Problem Solving",
+    issuer: "LeetCode",
+    credentialUrl: "https://leetcode.com/u/joaoptgrilo/",
+    description: (
+      <>
+        Actively solving challenges to sharpen{" "}
+        <Highlight>algorithmic thinking</Highlight> and master{" "}
+        <Highlight>data structures</Highlight> for optimal, efficient code.
+      </>
+    ),
+    isInProgress: true,
+  },
+  {
+    id: "aws-cloud-quest",
+    name: "AWS Cloud Quest",
+    issuer: "Amazon Web Services",
+    credentialUrl: "https://www.credly.com/users/joao.grilo.dev",
+    description: (
+      <>
+        Hands-on learning for <Highlight>AWS Cloud fundamentals</Highlight> and
+        core services, pursuing the <Highlight>Cloud Practitioner</Highlight>{" "}
+        role and other badges.
+      </>
+    ),
+    isInProgress: true,
+  },
+  {
+    id: "tryhackme-learning-paths",
+    name: "TryHackMe Learning Paths",
+    issuer: "TryHackMe",
+    credentialUrl: "https://tryhackme.com/p/joao.grilo.dev",
+    description: (
+      <>
+        Progressing through cybersecurity paths, including{" "}
+        <Highlight>Web Hacking</Highlight> and{" "}
+        <Highlight>Offensive Pentesting</Highlight>, to build a defensive
+        mindset.
+      </>
+    ),
+    isInProgress: true,
+  },
+  // END: NEW/UPDATED "CONTINUED LEARNING" ITEMS
 ];


### PR DESCRIPTION
### Description
This PR addresses Task #51 by adding cards for LeetCode, AWS Cloud Quest, and TryHackMe to the "Certifications & Continued Learning" section. This centralizes the showcase of ongoing learning and creates a consistent UI pattern for the user.

### Changes Made
- **`certificationsData.tsx`**: Added new "in-progress" data objects for LeetCode, AWS, and TryHackMe with links to their respective public profiles.
- **`Certifications.tsx`**: Implemented conditional logic to display a different icon (`FiActivity`) and a "View Progress" button for items marked `isInProgress: true`.
- **`Skills.tsx`**: Removed the special link from the "Problem Solving & DSA" title and the "LeetCode" skill tag to consolidate this information in the new card, improving UX consistency.

### How to Test
1. Run the application locally.
2. Scroll to the "Certifications & Continued Learning" section.
3. Verify that three new cards for LeetCode, AWS, and TryHackMe are visible.
4. Confirm that these new cards have a "View Progress" button and an activity icon.
5. Click each "View Progress" button and confirm they open the correct profile link in a new tab.
6. Verify that the "Problem Solving & DSA" title in the Skills section is no longer a link.

### Related Issue
Closes #51.